### PR TITLE
Don't output stderr to stdout

### DIFF
--- a/lib/plugins/tf/text_output.rb
+++ b/lib/plugins/tf/text_output.rb
@@ -39,7 +39,7 @@ class TF::TextOutput
   end
 
   def command_err err
-    puts err
+    $stderr.puts err
   end
 
   def test_processed test, status, msg


### PR DESCRIPTION
Hi, here's a bug I ran into:

``` bash
# stderr_comment_test.sh
echo "output on stdout"
echo "output on stderr" >&2
```

When I run `tf --text stderr_comment_test.sh`, the last line should be outputted to _stderr_, not _stdout_.

In other words, if I execute `tf --text stderr_comment_test.sh 1>/dev/null`:
- expected output: `output on stderr`
- current output: nothing

I've had a look at the testsuite but I'm not sure where to add a test for this bug. Any pointers? On the other hand, this is pretty straightforward and might not need a test.
