### PR TITLE
Add license info to the gemspec.

### DIFF
--- a/tf.gemspec
+++ b/tf.gemspec
@@ -4,6 +4,7 @@ Gem::Specification.new do |s|
   s.summary = "Testing Framework"
   s.email = "mpapis+tf@gmail.com"
   s.homepage = "http://github.com/mpapis/tf"
+  s.license = "Apache-2.0"
   s.description = "Testing Framework solely based on plugins. For now only tests using Bash."
   s.has_rdoc = false
   s.author = "Michal Papis"


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.